### PR TITLE
feat: scaffold YWC website

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['next', 'next/core-web-vitals'],
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+out
+tsconfig.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# YWC
+# Yes We Can Technologies
+
+This is a minimal demo of the YWC website built with Next.js 14, TypeScript, Tailwind CSS and next-intl.
+
+## Getting Started
+
+```bash
+npm install
+npm run dev
+```
+
+## Production Build
+
+```bash
+npm run build && npm start
+```
+
+Important contact info is located in `components/footer.tsx`. Update Telegram link in `components/telegram-button.tsx`.

--- a/app/[locale]/about/page.tsx
+++ b/app/[locale]/about/page.tsx
@@ -1,0 +1,6 @@
+import {useTranslations} from 'next-intl';
+
+export default function AboutPage() {
+  const t = useTranslations('About');
+  return <h1 className="py-20 text-center text-3xl font-heading">{t('title')}</h1>;
+}

--- a/app/[locale]/blog/[slug]/page.tsx
+++ b/app/[locale]/blog/[slug]/page.tsx
@@ -1,0 +1,11 @@
+import {useTranslations} from 'next-intl';
+
+export default function BlogPostPage({params}: {params: {slug: string}}) {
+  const t = useTranslations('Blog');
+  return (
+    <div className="py-20 text-center">
+      <h1 className="mb-4 text-3xl font-heading">{t('title')}</h1>
+      <p>{params.slug}</p>
+    </div>
+  );
+}

--- a/app/[locale]/blog/page.tsx
+++ b/app/[locale]/blog/page.tsx
@@ -1,0 +1,6 @@
+import {useTranslations} from 'next-intl';
+
+export default function BlogPage() {
+  const t = useTranslations('Blog');
+  return <h1 className="py-20 text-center text-3xl font-heading">{t('title')}</h1>;
+}

--- a/app/[locale]/careers/page.tsx
+++ b/app/[locale]/careers/page.tsx
@@ -1,0 +1,6 @@
+import {useTranslations} from 'next-intl';
+
+export default function CareersPage() {
+  const t = useTranslations('Careers');
+  return <h1 className="py-20 text-center text-3xl font-heading">{t('title')}</h1>;
+}

--- a/app/[locale]/cases/[slug]/page.tsx
+++ b/app/[locale]/cases/[slug]/page.tsx
@@ -1,0 +1,11 @@
+import {useTranslations} from 'next-intl';
+
+export default function CasePage({params}: {params: {slug: string}}) {
+  const t = useTranslations('Cases');
+  return (
+    <div className="py-20 text-center">
+      <h1 className="mb-4 text-3xl font-heading">{t('title')}</h1>
+      <p>{params.slug}</p>
+    </div>
+  );
+}

--- a/app/[locale]/cases/page.tsx
+++ b/app/[locale]/cases/page.tsx
@@ -1,0 +1,6 @@
+import {useTranslations} from 'next-intl';
+
+export default function CasesPage() {
+  const t = useTranslations('Cases');
+  return <h1 className="py-20 text-center text-3xl font-heading">{t('title')}</h1>;
+}

--- a/app/[locale]/contact/page.tsx
+++ b/app/[locale]/contact/page.tsx
@@ -1,0 +1,12 @@
+import {useTranslations} from 'next-intl';
+import TelegramButton from '../../components/telegram-button';
+
+export default function ContactPage() {
+  const t = useTranslations('Contact');
+  return (
+    <div className="py-20 text-center">
+      <h1 className="mb-4 text-3xl font-heading">{t('title')}</h1>
+      <TelegramButton />
+    </div>
+  );
+}

--- a/app/[locale]/dpa/page.tsx
+++ b/app/[locale]/dpa/page.tsx
@@ -1,0 +1,6 @@
+import {useTranslations} from 'next-intl';
+
+export default function DpaPage() {
+  const t = useTranslations('DPA');
+  return <h1 className="py-20 text-center text-3xl font-heading">{t('title')}</h1>;
+}

--- a/app/[locale]/industries/fintech/page.tsx
+++ b/app/[locale]/industries/fintech/page.tsx
@@ -1,0 +1,3 @@
+export default function FintechPage() {
+  return <h1 className="py-20 text-center text-3xl font-heading">Fintech</h1>;
+}

--- a/app/[locale]/industries/govtech/page.tsx
+++ b/app/[locale]/industries/govtech/page.tsx
@@ -1,0 +1,3 @@
+export default function GovtechPage() {
+  return <h1 className="py-20 text-center text-3xl font-heading">GovTech</h1>;
+}

--- a/app/[locale]/industries/healthtech/page.tsx
+++ b/app/[locale]/industries/healthtech/page.tsx
@@ -1,0 +1,3 @@
+export default function HealthtechPage() {
+  return <h1 className="py-20 text-center text-3xl font-heading">Healthtech</h1>;
+}

--- a/app/[locale]/industries/page.tsx
+++ b/app/[locale]/industries/page.tsx
@@ -1,0 +1,6 @@
+import {useTranslations} from 'next-intl';
+
+export default function IndustriesPage() {
+  const t = useTranslations('Industries');
+  return <h1 className="py-20 text-center text-3xl font-heading">{t('title')}</h1>;
+}

--- a/app/[locale]/industries/retail/page.tsx
+++ b/app/[locale]/industries/retail/page.tsx
@@ -1,0 +1,3 @@
+export default function RetailPage() {
+  return <h1 className="py-20 text-center text-3xl font-heading">Retail</h1>;
+}

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -1,0 +1,36 @@
+import '../../styles/globals.css';
+import {Inter, Manrope} from 'next/font/google';
+import {NextIntlClientProvider} from 'next-intl';
+import {notFound} from 'next/navigation';
+import Header from '../../components/header';
+import Footer from '../../components/footer';
+import TelegramButton from '../../components/telegram-button';
+
+const inter = Inter({subsets: ['latin'], variable: '--font-sans'});
+const manrope = Manrope({subsets: ['latin'], variable: '--font-heading'});
+
+export default async function LocaleLayout({children, params}: {children: React.ReactNode; params: {locale: string}}) {
+  let messages;
+  try {
+    messages = (await import(`../../messages/${params.locale}.json`)).default;
+  } catch (error) {
+    notFound();
+  }
+  return (
+    <html lang={params.locale} className={`${inter.variable} ${manrope.variable}`}> 
+      <body className="min-h-screen bg-background text-white">
+        <a href="#main" className="skip-link">
+          Skip to content
+        </a>
+        <NextIntlClientProvider locale={params.locale} messages={messages}>
+          <Header />
+          <main id="main" className="flex-1">
+            {children}
+          </main>
+          <Footer />
+          <TelegramButton className="fixed bottom-4 right-4 sm:hidden" />
+        </NextIntlClientProvider>
+      </body>
+    </html>
+  );
+}

--- a/app/[locale]/offer/page.tsx
+++ b/app/[locale]/offer/page.tsx
@@ -1,0 +1,6 @@
+import {useTranslations} from 'next-intl';
+
+export default function OfferPage() {
+  const t = useTranslations('Offer');
+  return <h1 className="py-20 text-center text-3xl font-heading">{t('title')}</h1>;
+}

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,0 +1,13 @@
+import {useTranslations} from 'next-intl';
+import TelegramButton from '../../components/telegram-button';
+
+export default function HomePage() {
+  const t = useTranslations('Home');
+  return (
+    <section className="py-20 text-center">
+      <h1 className="mb-4 text-4xl font-heading">{t('tagline')}</h1>
+      <p className="mb-8">{t('description')}</p>
+      <TelegramButton />
+    </section>
+  );
+}

--- a/app/[locale]/platforms/cando/page.tsx
+++ b/app/[locale]/platforms/cando/page.tsx
@@ -1,0 +1,6 @@
+import {useTranslations} from 'next-intl';
+
+export default function CandoPage() {
+  const t = useTranslations('Platform');
+  return <h1 className="py-20 text-center text-3xl font-heading">{t('title')}</h1>;
+}

--- a/app/[locale]/privacy/page.tsx
+++ b/app/[locale]/privacy/page.tsx
@@ -1,0 +1,6 @@
+import {useTranslations} from 'next-intl';
+
+export default function PrivacyPage() {
+  const t = useTranslations('Privacy');
+  return <h1 className="py-20 text-center text-3xl font-heading">{t('title')}</h1>;
+}

--- a/app/[locale]/services/page.tsx
+++ b/app/[locale]/services/page.tsx
@@ -1,0 +1,6 @@
+import {useTranslations} from 'next-intl';
+
+export default function ServicesPage() {
+  const t = useTranslations('Services');
+  return <h1 className="py-20 text-center text-3xl font-heading">{t('title')}</h1>;
+}

--- a/app/[locale]/terms/page.tsx
+++ b/app/[locale]/terms/page.tsx
@@ -1,0 +1,6 @@
+import {useTranslations} from 'next-intl';
+
+export default function TermsPage() {
+  const t = useTranslations('Terms');
+  return <h1 className="py-20 text-center text-3xl font-heading">{t('title')}</h1>;
+}

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,0 +1,7 @@
+import {NextResponse} from 'next/server';
+
+export async function POST(request: Request) {
+  const data = await request.json();
+  console.log('contact form', data);
+  return NextResponse.json({success: true});
+}

--- a/app/api/estimate/route.ts
+++ b/app/api/estimate/route.ts
@@ -1,0 +1,7 @@
+import {NextResponse} from 'next/server';
+
+export async function POST(request: Request) {
+  const data = await request.json();
+  console.log('estimate', data);
+  return NextResponse.json({success: true, estimate: 0});
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,3 @@
+export default function RootLayout({children}: {children: React.ReactNode}) {
+  return children;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,5 @@
+import {redirect} from 'next/navigation';
+
+export default function IndexPage() {
+  redirect('/ru');
+}

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,0 +1,16 @@
+import {useTranslations} from 'next-intl';
+
+export default function Footer() {
+  const t = useTranslations('Footer');
+  return (
+    <footer className="mt-16 border-t border-white/10 py-8 text-center text-sm">
+      <p className="mb-2">+998 99 791 55 41</p>
+      <p className="mb-2">
+        <a href="mailto:ywctechuz@gmail.com" className="underline">
+          ywctechuz@gmail.com
+        </a>
+      </p>
+      <p>Uzbekistan, Tashkent (online)</p>
+    </footer>
+  );
+}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,0 +1,37 @@
+import Link from 'next/link';
+import {useLocale, useTranslations} from 'next-intl';
+import TelegramButton from './telegram-button';
+import LocaleSwitcher from './locale-switcher';
+import ThemeSwitcher from './theme-switcher';
+
+export default function Header() {
+  const t = useTranslations('Nav');
+  const locale = useLocale();
+  const nav = [
+    {href: `/${locale}/services`, label: t('services')},
+    {href: `/${locale}/industries`, label: t('industries')},
+    {href: `/${locale}/cases`, label: t('cases')},
+    {href: `/${locale}/blog`, label: t('blog')},
+    {href: `/${locale}/careers`, label: t('careers')},
+    {href: `/${locale}/contact`, label: t('contact')}
+  ];
+  return (
+    <header className="flex items-center justify-between py-4">
+      <Link href={`/${locale}`} className="flex items-center gap-2">
+        <span className="font-heading text-xl">YWC</span>
+      </Link>
+      <nav className="hidden md:flex gap-4">
+        {nav.map((item) => (
+          <Link key={item.href} href={item.href} className="hover:underline focus-visible:underline">
+            {item.label}
+          </Link>
+        ))}
+      </nav>
+      <div className="flex items-center gap-2">
+        <LocaleSwitcher />
+        <ThemeSwitcher />
+        <TelegramButton className="hidden sm:inline-flex" />
+      </div>
+    </header>
+  );
+}

--- a/components/locale-switcher.tsx
+++ b/components/locale-switcher.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import Link from 'next/link';
+import {useLocale} from 'next-intl';
+import {usePathname} from 'next/navigation';
+
+const locales = ['ru', 'uz', 'en'];
+
+export default function LocaleSwitcher() {
+  const locale = useLocale();
+  const pathname = usePathname();
+  const segments = pathname.split('/').slice(2); // remove leading '' and locale
+  const rest = segments.join('/');
+  return (
+    <div className="flex gap-1 text-sm">
+      {locales.map((l) => (
+        <Link key={l} href={`/${l}/${rest}`} className={l === locale ? 'underline' : 'hover:underline'}>
+          {l.toUpperCase()}
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/components/telegram-button.tsx
+++ b/components/telegram-button.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import {useTranslations} from 'next-intl';
+import Link from 'next/link';
+import {cn} from '@/lib/utils';
+
+export default function TelegramButton({className, size = 'lg'}: {className?: string; size?: 'lg' | 'sm'}) {
+  const t = useTranslations('Common');
+  const sizes = size === 'lg' ? 'px-6 py-3 text-lg' : 'px-3 py-2 text-sm';
+  return (
+    <Link
+      href="https://t.me/ywctech"
+      className={cn(
+        'rounded-2xl bg-accent text-white shadow hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent',
+        sizes,
+        className
+      )}
+    >
+      {t('telegram')}
+    </Link>
+  );
+}

--- a/components/theme-switcher.tsx
+++ b/components/theme-switcher.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import {useEffect, useState} from 'react';
+
+export default function ThemeSwitcher() {
+  const [theme, setTheme] = useState<'light' | 'dark'>(() =>
+    typeof window !== 'undefined' && document.documentElement.classList.contains('dark') ? 'dark' : 'light'
+  );
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', theme === 'dark');
+  }, [theme]);
+  return (
+    <button
+      type="button"
+      aria-label="Toggle theme"
+      className="rounded-2xl border border-white/20 p-2"
+      onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+    >
+      {theme === 'dark' ? '🌙' : '☀️'}
+    </button>
+  );
+}

--- a/content/blog/hello.mdx
+++ b/content/blog/hello.mdx
@@ -1,0 +1,8 @@
+---
+title: "Hello"
+date: 2024-01-01
+---
+
+# Hello World
+
+This is a blog post.

--- a/content/cases/sample-case.mdx
+++ b/content/cases/sample-case.mdx
@@ -1,0 +1,8 @@
+---
+title: "Sample Case"
+slug: "sample-case"
+---
+
+# Sample Case
+
+Demo content.

--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -1,0 +1,26 @@
+import {defineDocumentType, makeSource} from 'contentlayer/source-files';
+
+export const Post = defineDocumentType(() => ({
+  name: 'Post',
+  filePathPattern: `blog/**/*.mdx`,
+  contentType: 'mdx',
+  fields: {
+    title: {type: 'string', required: true},
+    date: {type: 'date', required: true}
+  }
+}));
+
+export const Case = defineDocumentType(() => ({
+  name: 'Case',
+  filePathPattern: `cases/**/*.mdx`,
+  contentType: 'mdx',
+  fields: {
+    title: {type: 'string', required: true},
+    slug: {type: 'string', required: true}
+  }
+}));
+
+export default makeSource({
+  contentDirPath: 'content',
+  documentTypes: [Post, Case]
+});

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,6 @@
+import {ClassValue, clsx} from 'clsx';
+import {twMerge} from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,0 +1,27 @@
+{
+  "Common": {"telegram": "Message on Telegram"},
+  "Nav": {
+    "services": "Services",
+    "industries": "Industries",
+    "cases": "Cases",
+    "blog": "Blog",
+    "careers": "Careers",
+    "contact": "Contact"
+  },
+  "Home": {
+    "tagline": "We build products. Launch faster. Scale reliably",
+    "description": "We craft digital solutions."
+  },
+  "Services": {"title": "Services"},
+  "Industries": {"title": "Industries"},
+  "Cases": {"title": "Cases"},
+  "Blog": {"title": "Blog"},
+  "Careers": {"title": "Careers"},
+  "Contact": {"title": "Contact"},
+  "About": {"title": "About"},
+  "Platform": {"title": "CanDo Platform"},
+  "Privacy": {"title": "Privacy Policy"},
+  "Terms": {"title": "Terms of Use"},
+  "Offer": {"title": "Public Offer"},
+  "DPA": {"title": "DPA"}
+}

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -1,0 +1,27 @@
+{
+  "Common": {"telegram": "Написать в Telegram"},
+  "Nav": {
+    "services": "Услуги",
+    "industries": "Отрасли",
+    "cases": "Кейсы",
+    "blog": "Блог",
+    "careers": "Вакансии",
+    "contact": "Контакты"
+  },
+  "Home": {
+    "tagline": "Создаём продукты. Запускаем быстрее. Масштабируем надёжно",
+    "description": "Мы строим цифровые решения."
+  },
+  "Services": {"title": "Наши услуги"},
+  "Industries": {"title": "Отрасли"},
+  "Cases": {"title": "Кейсы"},
+  "Blog": {"title": "Блог"},
+  "Careers": {"title": "Вакансии"},
+  "Contact": {"title": "Контакты"},
+  "About": {"title": "О нас"},
+  "Platform": {"title": "Платформа CanDo"},
+  "Privacy": {"title": "Политика конфиденциальности"},
+  "Terms": {"title": "Условия использования"},
+  "Offer": {"title": "Публичная оферта"},
+  "DPA": {"title": "DPA"}
+}

--- a/messages/uz.json
+++ b/messages/uz.json
@@ -1,0 +1,27 @@
+{
+  "Common": {"telegram": "Telegramga yozish"},
+  "Nav": {
+    "services": "Xizmatlar",
+    "industries": "Sohalar",
+    "cases": "Keyslar",
+    "blog": "Blog",
+    "careers": "Vakansiyalar",
+    "contact": "Aloqa"
+  },
+  "Home": {
+    "tagline": "Mahsulotlar yaratamiz. Tezroq ishga tushiramiz. Ishonchli kengaytiramiz",
+    "description": "Biz raqamli yechimlar yaratamiz."
+  },
+  "Services": {"title": "Xizmatlar"},
+  "Industries": {"title": "Sohalar"},
+  "Cases": {"title": "Keyslar"},
+  "Blog": {"title": "Blog"},
+  "Careers": {"title": "Vakansiyalar"},
+  "Contact": {"title": "Aloqa"},
+  "About": {"title": "Biz haqimizda"},
+  "Platform": {"title": "CanDo Platformasi"},
+  "Privacy": {"title": "Maxfiylik siyosati"},
+  "Terms": {"title": "Foydalanish shartlari"},
+  "Offer": {"title": "Ommaviy oferta"},
+  "DPA": {"title": "DPA"}
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,12 @@
+import {nextIntl} from 'next-intl/plugin';
+import type {NextConfig} from 'next';
+
+const withNextIntl = nextIntl();
+
+const config: NextConfig = {
+  experimental: {
+    appDir: true
+  }
+};
+
+export default withNextIntl(config);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "ywc",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "check": "npm run typecheck && npm run lint && npm test",
+    "typecheck": "tsc --noEmit",
+    "lint": "next lint",
+    "test": "echo 'No tests'"
+  },
+  "dependencies": {
+    "@hookform/resolvers": "^3.3.2",
+    "@radix-ui/react-slot": "^1.0.2",
+    "autoprefixer": "^10.4.16",
+    "class-variance-authority": "^0.7.0",
+    "contentlayer": "^0.3.2",
+    "framer-motion": "^10.16.4",
+    "lucide-react": "^0.376.0",
+    "next": "14.2.3",
+    "next-intl": "^3.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-hook-form": "^7.50.0",
+    "shadcn-ui": "0.8.0",
+    "tailwind-merge": "^2.2.1",
+    "tailwindcss": "^3.4.1",
+    "zod": "^3.22.4",
+    "clsx": "^2.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.17",
+    "@types/react": "^18.2.37",
+    "@types/react-dom": "^18.2.15",
+    "eslint": "^8.56.0",
+    "eslint-config-next": "14.2.3",
+    "postcss": "^8.4.31",
+    "typescript": "^5.4.2"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,30 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  @apply bg-background text-white;
+}
+
+.skip-link {
+  position: absolute;
+  left: -1000px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+.skip-link:focus {
+  left: 0;
+  width: auto;
+  height: auto;
+  padding: 0.5rem;
+  background: #fff;
+  color: #000;
+  z-index: 1000;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,22 @@
+import type {Config} from 'tailwindcss';
+import {fontFamily} from 'tailwindcss/defaultTheme';
+
+const config: Config = {
+  darkMode: 'class',
+  content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}', './content/**/*.{md,mdx}'],
+  theme: {
+    extend: {
+      colors: {
+        background: '#0A2430',
+        accent: '#14B8A6'
+      },
+      fontFamily: {
+        sans: ['Inter', ...fontFamily.sans],
+        heading: ['Manrope', ...fontFamily.sans]
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,40 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": [
+      "DOM",
+      "DOM.Iterable",
+      "ESNext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": [
+      "node"
+    ],
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.cjs",
+    "**/*.mjs"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## Summary
- remove binary logo asset and use text branding in header
- add gitignore to exclude build artifacts

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@hookform%2fresolvers)*
- `npm run lint` *(fails: next: not found)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689778163f5c832dae424eb1ee5be697